### PR TITLE
Correcting Chains of Ice to work 100% as intended.

### DIFF
--- a/cards/src/main/resources/cards/custom/group2/deathknight1/spell_chains_of_ice.json
+++ b/cards/src/main/resources/cards/custom/group2/deathknight1/spell_chains_of_ice.json
@@ -7,27 +7,27 @@
   "description": "Silence a minion, then Freeze it. If it was already Frozen, draw a card.",
   "targetSelection": "MINIONS",
   "spell": {
-    "class": "MetaSpell",
-    "spells": [
-      {
+    "class": "EitherOrSpell",
+    "condition": {
+      "class": "AttributeCondition",
+      "attribute": "FROZEN",
+      "operation": "HAS"
+    },
+    "spell1": {
+      "class": "DrawCardSpell"
+    },
+    "spell2": {
+      "class": "MetaSpell",
+      "spells": [
+        {
         "class": "SilenceSpell"
-      },
-      {
-        "class": "EitherOrSpell",
-        "condition": {
-          "class": "AttributeCondition",
-          "attribute": "FROZEN",
-          "operation": "HAS"
         },
-        "spell1": {
-          "class": "DrawCardSpell"
-        },
-        "spell2": {
-          "class": "AddAttributeSpell",
-          "attribute": "FROZEN"
+        {
+        "class": "AddAttributeSpell",
+        "attribute": "FROZEN"
         }
-      }
-    ]
+      ]
+    }
   },
   "collectible": true,
   "set": "CUSTOM",


### PR DESCRIPTION
Its current iteration now no longer draws a card even if the minion was already frozen and it's previous iteration always drew a card even when the minion was not frozen prior.