### PR TITLE
Breath of Fire updates.

### DIFF
--- a/cards/src/main/resources/cards/custom/group2/set_633/spell_breath_of_fire.json
+++ b/cards/src/main/resources/cards/custom/group2/set_633/spell_breath_of_fire.json
@@ -11,16 +11,17 @@
     "spells": [
       {
         "class": "DamageSpell",
-        "target": "ENEMY_HERO",
-        "value": {
-          "class": "EntityCounter",
-          "target": "ENEMY_MINIONS"
-        }
+        "target": "ENEMY_MINIONS",
+        "value": 1
       },
       {
         "class": "DamageSpell",
-        "target": "ENEMY_MINIONS",
-        "value": 1
+        "target": "ENEMY_HERO",
+        "value": {
+          "class": "EntityCounter",
+          "target": "ENEMY_MINIONS",
+          "ignoreSpellDamage": true
+        }
       }
     ]
   },


### PR DESCRIPTION
Now damages minions before damaging heroes.

Damage to heroes no longer benefits from Spell Damage.