### PR TITLE
Wandering Monster secret not triggering

### DIFF
--- a/cards/src/main/resources/cards/hearthstone/kobolds_and_catacombs/hunter/secret_wandering_monster.json
+++ b/cards/src/main/resources/cards/hearthstone/kobolds_and_catacombs/hunter/secret_wandering_monster.json
@@ -18,9 +18,9 @@
       "value": 7,
       "operation": "LESS"
     },
-    "sourcePlayer": "BOTH",
+    "sourcePlayer": "OPPONENT",
     "targetEntityType": "HERO",
-    "targetPlayer": "OPPONENT"
+    "targetPlayer": "OWNER"
   },
   "spell": {
     "class": "SummonSpell",

--- a/game/src/test/java/com/blizzard/hearthstone/KoboldsAndCatacombsTests.java
+++ b/game/src/test/java/com/blizzard/hearthstone/KoboldsAndCatacombsTests.java
@@ -1017,4 +1017,17 @@ public class KoboldsAndCatacombsTests extends TestBase {
 		});
 
 	}
+
+	@Test
+	public void testWanderingMonster(){
+		runGym((context, player, opponent) -> {
+			playCard(context, player, "secret_wandering_monster");
+			context.endTurn();
+			Minion bloodfen = playMinionCard(context, opponent, "minion_bloodfen_raptor");
+			context.endTurn();
+			context.endTurn();
+			attack(context, opponent, bloodfen, player.getHero());
+			assertTrue((int) player.getAttributes().get(Attribute.MINIONS_SUMMONED_THIS_TURN) > 0);
+		});
+	}
 }


### PR DESCRIPTION
Wandering Monster secret isn't triggering while playing the Spell Hunter deck against AI. Fix and test case are added. Can open an issue if needed.