### PR TITLE
Fix Mad Hatter Target Error

### DIFF
--- a/cards/src/main/resources/cards/hearthstone/witchwood/collectible/minion_mad_hatter.json
+++ b/cards/src/main/resources/cards/hearthstone/witchwood/collectible/minion_mad_hatter.json
@@ -11,12 +11,13 @@
     "targetSelection": "NONE",
     "spell": {
       "class": "CastRepeatedlySpell",
-      "target": "FRIENDLY_MINIONS",
+      "target": "ALL_OTHER_MINIONS",
       "spell": {
         "class": "BuffSpell",
         "attackBonus": 1,
         "hpBonus": 1
       },
+      "randomTarget": true,
       "exclusive": true,
       "howMany": 3
     }


### PR DESCRIPTION
Mad Hatter should target all minions instead of friendly minions.