### PR TITLE
Nerf minion_sideline_coach.json to 5 Mana

### DIFF
--- a/cards/src/main/resources/cards/custom/group2/baron/minion_sideline_coach.json
+++ b/cards/src/main/resources/cards/custom/group2/baron/minion_sideline_coach.json
@@ -1,6 +1,6 @@
 {
   "name": "Sideline Coach",
-  "baseManaCost": 2,
+  "baseManaCost": 5,
   "type": "MINION",
   "heroClass": "NAVY",
   "baseAttack": 1,


### PR DESCRIPTION
This is because it snowballs very easily with all of your minions and can get out of hand quickly, 5 mana is when removal becomes readily available.