### PR TITLE
Wavering Diabolist now correctly indicates that it doesn't have Guard.

### DIFF
--- a/cards/src/main/resources/cards/custom/group8/neutral/minion_wavering_diabloist.json
+++ b/cards/src/main/resources/cards/custom/group8/neutral/minion_wavering_diabloist.json
@@ -7,7 +7,7 @@
   "baseHp": 6,
   "rarity": "RARE",
   "race": "DEMON",
-  "description": "Guard. Opener: Deal 2 damage to all other characters, then restore #2 Health to any survivors.",
+  "description": "Opener: Deal 2 damage to all other characters, then restore #2 Health to any survivors.",
   "battlecry": {
     "targetSelection": "NONE",
     "spell": {

--- a/www/whatsnew.md
+++ b/www/whatsnew.md
@@ -20,6 +20,7 @@ Bug fixes.
  - Kahl of the Deep is now a 3/5, cost 5, that draws 3 cards for the opponent instead of 8. (1182)
  - Yig's Mastermind cost increased from 8 to 10. (1184)
  - Ahn'quiraj Portal renamed to Ancient Waygate and reads "Deal 2 damage to all minions. Summon a random 2-Cost minion." (1185)
+ - Wavering Diabolist correctly indicates that it does not have Guard. (1203)
 
 ### 0.8.33-2.0.31 (Tuesday, June 18th, 2019)
 


### PR DESCRIPTION
fix #1190 