### PR TITLE
The Omega Rune now correctly only gives lifesteal to spells that the …

### DIFF
--- a/cards/src/main/resources/cards/custom/group0/other_death_knight/ungoro/spell_the_omega_rune.json
+++ b/cards/src/main/resources/cards/custom/group0/other_death_knight/ungoro/spell_the_omega_rune.json
@@ -39,7 +39,7 @@
           "eventTrigger": {
             "class": "CardPlayedTrigger",
             "cardType": "SPELL",
-            "sourcePlayer": "SELF"
+            "targetPlayer": "SELF"
           },
           "spell": {
             "class": "AddAttributeSpell",

--- a/game/src/test/java/com/hiddenswitch/spellsource/CustomCardsTests.java
+++ b/game/src/test/java/com/hiddenswitch/spellsource/CustomCardsTests.java
@@ -7409,4 +7409,21 @@ public class CustomCardsTests extends TestBase {
 			assertEquals(warden2.getHp(), warden2.getMaxHp());
 		}));
 	}
+
+	@Test
+	public void testOmegaRune() {
+		runGym(((context, player, opponent) -> {
+			playCard(context, player, "spell_the_omega_rune");
+			player.getHero().setHp(20);
+			opponent.getHero().setHp(20);
+
+			playCard(context, player, "spell_test_deal_5_to_enemy_hero");
+			assertEquals(opponent.getHero().getHp(), 15);
+			assertEquals(player.getHero().getHp(), 25);
+
+			playCard(context, opponent, "spell_test_deal_5_to_enemy_hero");
+			assertEquals(opponent.getHero().getHp(), 15);
+			assertEquals(player.getHero().getHp(), 20);
+		}));
+	}
 }

--- a/www/whatsnew.md
+++ b/www/whatsnew.md
@@ -33,6 +33,7 @@ The bot will now play more new decks in its rotation. Additionally, there are bu
  - Might Mufunga now costs (9), up from (8). (1257)
  - Guild Guard now costs (5), up from (4). (1257)
  - Miserable Conclusion now correctly destroys all minions except the opponent's highest attack minion.
+ - The Omega Rune now correctly no longer gives lifesteal on spell casts to both players. (1265)
 
 ### 0.8.40-2.0.35 (July 16th, 2019)
 


### PR DESCRIPTION
…caster plays

fix #1256 