### PR TITLE
Dragon Caretaker now correctly can only target friendly dragons

### DIFF
--- a/cards/src/main/resources/cards/custom/group3/set_1087/minion_dragon_caretaker.json
+++ b/cards/src/main/resources/cards/custom/group3/set_1087/minion_dragon_caretaker.json
@@ -8,11 +8,11 @@
   "rarity": "RARE",
   "description": "Opener: Give a friendly Dragon +2 Health.",
   "battlecry": {
-    "targetSelection": "MINIONS",
+    "targetSelection": "FRIENDLY_MINIONS",
     "spell": {
       "class": "BuffSpell",
       "hpBonus": 2,
-      "cardFilter": {
+      "filter": {
         "class": "CardFilter",
         "race": "DRAGON"
       }

--- a/game/src/test/java/com/hiddenswitch/spellsource/CustomCardsTests.java
+++ b/game/src/test/java/com/hiddenswitch/spellsource/CustomCardsTests.java
@@ -7035,6 +7035,26 @@ public class CustomCardsTests extends TestBase {
 			playMinionCard(context, player, "minion_dragon_caretaker");
 			assertEquals(dragon.getHp(), dragon.getBaseHp() + 2);
 		});
+
+		runGym((context, player, opponent) -> {
+			Minion nonDragon = playMinionCard(context, player, "minion_test_3_2");
+			overrideBattlecry(context, player, battlecryActions -> {
+				assertEquals(battlecryActions.size(), 0);
+				return battlecryActions.get(0);
+			});
+			playMinionCard(context, player, "minion_dragon_caretaker");
+			assertEquals(nonDragon.getHp(), nonDragon.getBaseHp());
+		});
+
+		runGym((context, player, opponent) -> {
+			Minion dragon = playMinionCard(context, opponent, "minion_blastflame_dragon");
+			overrideBattlecry(context, player, battlecryActions -> {
+				assertEquals(battlecryActions.size(), 0);
+				return battlecryActions.get(0);
+			});
+			playMinionCard(context, player, "minion_dragon_caretaker");
+			assertEquals(dragon.getHp(), dragon.getBaseHp());
+		});
 	}
 
 	// Siphonscale Blade - 8 Mana 6/3 Weapon Epic "Can attack again after a friendly minion attacks and kills a minion."

--- a/www/whatsnew.md
+++ b/www/whatsnew.md
@@ -39,6 +39,7 @@ The bot will now play more new decks in its rotation. Additionally, there are bu
  - Manly Mountaineer now properly has Dash. (1233)
  - Tome of Secrets now works properly. (1233)
  - Dramatic Playwright now only changes the attack of one enemy minion. (1233)
+ - Dragon Caretaker now correctly can only target friendly Dragons. (1278)
 
 ### 0.8.40-2.0.35 (July 16th, 2019)
 

--- a/www/whatsnew.md
+++ b/www/whatsnew.md
@@ -3,6 +3,7 @@ layout: page
 title: What's New
 permalink: /whats-new/
 ---
+ - Dragon Caretaker now correctly can only target friendly Dragons. (1278)
 
 ### 0.8.41-2.0.35 (In Progress)
 
@@ -39,7 +40,6 @@ The bot will now play more new decks in its rotation. Additionally, there are bu
  - Manly Mountaineer now properly has Dash. (1233)
  - Tome of Secrets now works properly. (1233)
  - Dramatic Playwright now only changes the attack of one enemy minion. (1233)
- - Dragon Caretaker now correctly can only target friendly Dragons. (1278)
 
 ### 0.8.40-2.0.35 (July 16th, 2019)
 


### PR DESCRIPTION
fix #1277 