### PR TITLE
Bloody Reconstruction now properly marked as a Spellsource card

### DIFF
--- a/cards/src/main/resources/cards/custom/group8/occultist/basic/spell_ancient_blood.json
+++ b/cards/src/main/resources/cards/custom/group8/occultist/basic/spell_ancient_blood.json
@@ -16,7 +16,10 @@
     }
   },
   "collectible": true,
-  "set": "BASIC",
+  "sets": [
+    "CUSTOM",
+    "BASIC"
+  ],
   "fileFormatVersion": 1,
   "dynamicDescription": [
     {

--- a/www/whatsnew.md
+++ b/www/whatsnew.md
@@ -14,6 +14,7 @@ Bug fixes.
  - Garbasu Monster now reads, "After this minion survives damage, gain +1/+1."
  - Catta the Merciless and Garbasu Monster no longer interact to cause an infinite loop when Garbasu faces off a 1-attack immune minion.
  - Replacing weapons no longer sometimes keeps their enchantments, like Decay, in play.
+ - Bloody Reconstruction now appears in the Collection again. (1342)
 
 ### 0.8.47-2.0.35 (August 5th, 2019)
 


### PR DESCRIPTION
fix #1337 