### PR TITLE
New Occultist Set, including Self Damage synergies and other cool things

### DIFF
--- a/cards/src/main/resources/cards/custom/group8/occultist/classic/spell_bloodmoon_ritual
+++ b/cards/src/main/resources/cards/custom/group8/occultist/classic/spell_bloodmoon_ritual
@@ -1,5 +1,5 @@
 {
-  "name": "Ritual of Obliteration",
+  "name": "Bloodmoon Ritual",
   "baseManaCost": 4,
   "type": "SPELL",
   "heroClass": "DARKGREEN",

--- a/cards/src/main/resources/cards/custom/group8/occultist/misc/minion_azathoth
+++ b/cards/src/main/resources/cards/custom/group8/occultist/misc/minion_azathoth
@@ -1,0 +1,52 @@
+{
+  "name": "Azathoth, Idiot God",
+  "baseManaCost": 10,
+  "type": "MINION",
+  "heroClass": "DARKGREEN",
+  "baseAttack": 1,
+  "baseHp": 20,
+  "rarity": "LEGENDARY",
+  "description": "Aftermath: Deal all damage dealt to this minion to all characters. (Deals [0] damage",
+  "trigger": {
+    "eventTrigger": {
+      "class": "DamageReceivedTrigger",
+      "hostTargetType": "IGNORE_OTHER_TARGETS"
+    },
+    "spell": {
+      "class": "ModifyAttributeSpell",
+      "target": "SELF",
+      "value": {
+        "class": "AttributeValueProvider",
+        "target": "SELF",
+        "attribute": "LAST_HIT"
+      },
+      "attribute": "RESERVED_INTEGER_1"
+    }
+  },
+  "deathrattle": {
+    "class": "DamageSpell",
+    "target": "ALL_CHARACTERS",
+    "value": {
+      "class": "AttributeValueProvider",
+      "target": "SELF",
+      "attribute": "RESERVED_INTEGER_1"
+    }
+  },
+  "attributes": {
+    "DEATHRATTLES": true,
+    "RESERVED_INTEGER_1": 0
+  },
+  "collectible": true,
+  "set": "CUSTOM",
+  "fileFormatVersion": 1,
+  "dynamicDescription": [
+    {
+      "class": "ValueDescription",
+      "value": {
+        "class": "AttributeValueProvider",
+        "target": "SELF",
+        "attribute": "RESERVED_INTEGER_1"
+      }
+    }
+  ]
+}

--- a/cards/src/main/resources/cards/custom/group8/occultist/misc/minion_bloodthirsty_maneater
+++ b/cards/src/main/resources/cards/custom/group8/occultist/misc/minion_bloodthirsty_maneater
@@ -1,0 +1,24 @@
+{
+  "name": "Bloodthirsty Maneater",
+  "baseManaCost": 4,
+  "type": "MINION",
+  "heroClass": "DARKGREEN",
+  "baseAttack": 1,
+  "baseHp": 7,
+  "rarity": "COMMON",
+  "description": "Whenever this minion takes damage, gain +2 Attack.",
+  "trigger": {
+    "eventTrigger": {
+      "class": "DamageReceivedTrigger",
+      "hostTargetType": "IGNORE_OTHER_TARGETS"
+    },
+    "spell": {
+      "class": "BuffSpell",
+      "target": "SELF",
+      "attackBonus": 2
+    }
+  },
+  "collectible": true,
+  "set": "CUSTOM",
+  "fileFormatVersion": 1
+}

--- a/cards/src/main/resources/cards/custom/group8/occultist/misc/minion_gobogeg
+++ b/cards/src/main/resources/cards/custom/group8/occultist/misc/minion_gobogeg
@@ -1,0 +1,26 @@
+{
+  "name": "Gobogeg",
+  "baseManaCost": 4,
+  "type": "MINION",
+  "heroClass": "DARKGREEN",
+  "baseAttack": 2,
+  "baseHp": 6,
+  "rarity": "LEGENDARY",
+  "description": "Whenever a friendly minion takes damage, give it +1/+1.",
+  "trigger": {
+    "eventTrigger": {
+      "class": "DamageReceivedTrigger",
+      "targetEntityType": "MINION",
+      "targetPlayer": "SELF"
+    },
+    "spell": {
+      "class": "BuffSpell",
+      "target": "EVENT_TARGET",
+      "attackBonus": 1,
+      "hpBonus": 1
+    }
+  },
+  "collectible": true,
+  "set": "CUSTOM",
+  "fileFormatVersion": 1
+}

--- a/cards/src/main/resources/cards/custom/group8/occultist/misc/minion_spawn_of_gobogeg
+++ b/cards/src/main/resources/cards/custom/group8/occultist/misc/minion_spawn_of_gobogeg
@@ -1,0 +1,25 @@
+{
+  "name": "Spawn of Gobogeg",
+  "baseManaCost": 3,
+  "type": "MINION",
+  "heroClass": "DARKGREEN",
+  "baseAttack": 1,
+  "baseHp": 3,
+  "rarity": "RARE",
+  "description": "Whenever this minion takes damage, deal 3 damage randomly split among all enemies.",
+  "trigger": {
+    "eventTrigger": {
+      "class": "DamageReceivedTrigger",
+      "hostTargetType": "IGNORE_OTHER_TARGETS"
+    },
+    "spell": {
+      "class": "MissilesSpell",
+      "target": "ENEMY_CHARACTERS",
+      "value": 1,
+      "howMany": 3
+    }
+  },
+  "collectible": true,
+  "fileFormatVersion": 1,
+  "sets": "CUSTOM"
+}

--- a/cards/src/main/resources/cards/custom/group8/occultist/misc/minion_twisted_flesh
+++ b/cards/src/main/resources/cards/custom/group8/occultist/misc/minion_twisted_flesh
@@ -1,0 +1,53 @@
+{
+  "name": "Twisted Flesh",
+  "baseManaCost": 5,
+  "type": "MINION",
+  "heroClass": "DARKGREEN",
+  "baseAttack": 7,
+  "baseHp": 4,
+  "rarity": "RARE",
+  "description": "Whenever this minion takes damage from your cards or your skill, restore it to full Health.",
+  "passiveTrigger": {
+    "eventTrigger": {
+      "class": "DamageReceivedTrigger",
+      "queueCondition": {
+        "class": "OrCondition",
+        "conditions": [
+          {
+            "class": "CardPropertyCondition",
+            "target": "EVENT_SOURCE",
+            "cardType": "MINION"
+          },
+          {
+            "class": "CardPropertyCondition",
+            "target": "EVENT_SOURCE",
+            "cardType": "SPELL"
+          },
+          {
+            "class": "CardPropertyCondition",
+            "target": "EVENT_SOURCE",
+            "cardType": "WEAPON"
+          },
+          {
+            "class": "CardPropertyCondition",
+            "target": "EVENT_SOURCE",
+            "cardType": "HERO_POWER"
+          }
+        ]
+      },
+      "sourcePlayer": "SELF",
+      "hostTargetType": "IGNORE_OTHER_TARGETS"
+    },
+    "spell": {
+      "class": "HealSpell",
+      "target": "SELF",
+      "value": {
+        "class": "AttributeValueProvider",
+        "attribute": "MAX_HP"
+      }
+    }
+  },
+  "collectible": true,
+  "set": "CUSTOM",
+  "fileFormatVersion": 1
+}

--- a/cards/src/main/resources/cards/custom/group8/occultist/misc/spell_cosmic_apparitions
+++ b/cards/src/main/resources/cards/custom/group8/occultist/misc/spell_cosmic_apparitions
@@ -1,0 +1,31 @@
+{
+  "name": "Cosmic Apparitions",
+  "baseManaCost": 2,
+  "type": "SPELL",
+  "heroClass": "DARKGREEN",
+  "rarity": "COMMON",
+  "description": "Discover a minion. Shuffle two copies of it into your deck.",
+  "targetSelection": "NONE",
+  "spell": {
+    "class": "MetaSpell",
+    "spells": [
+      {
+        "class": "DiscoverSpell",
+        "spell": {
+          "class": "ShuffleToDeckSpell",
+          "value": 2,
+          "cardFilter": {
+            "class": "CardFilter",
+            "cardType": "MINION"
+          },
+          "cardSource": {
+            "class": "CatalogueSource"
+          }
+         }
+        }
+       ]
+      },
+      "collectible": true,
+      "set": "CUSTOM",
+      "fileFormatVersion": 1
+}

--- a/cards/src/main/resources/cards/custom/group8/occultist/misc/spell_grasp_of_god
+++ b/cards/src/main/resources/cards/custom/group8/occultist/misc/spell_grasp_of_god
@@ -1,0 +1,20 @@
+{
+  "name": "Grasp of God",
+  "baseManaCost": 2,
+  "type": "SPELL",
+  "heroClass": "DARKGREEN",
+  "rarity": "COMMON",
+  "description": "Destroy a friendly minion. At the start of your next turn, resummon it.",
+  "targetSelection": "FRIENDLY_MINIONS",
+  "spell": {
+    "class": "JailMinionSpell",
+    "secondaryTarget": "FRIENDLY_PLAYER",
+    "revertTrigger": {
+      "class": "TurnStartTrigger",
+      "targetPlayer": "SELF",
+      }
+    },
+  "collectible": true,
+  "set": "CUSTOM",
+  "fileFormatVersion": 1
+}

--- a/cards/src/main/resources/cards/custom/group8/occultist/misc/spell_necronomicon
+++ b/cards/src/main/resources/cards/custom/group8/occultist/misc/spell_necronomicon
@@ -1,0 +1,33 @@
+{
+  "name": "Necronomicon",
+  "baseManaCost": 1,
+  "type": "SPELL",
+  "heroClass": "LIGHTBROWN",
+  "rarity": "COMMON",
+  "description": "Take 3 damage, Discover a card. Repeatable this turn.",
+  "targetSelection": "NONE",
+  "spell": {
+    "class": "Metaspell",
+    "spells": [
+      {
+    "class": "DiscoverSpell",
+    "spell": {
+      "class": "ReceiveCardSpell",
+      "targetPlayer": "SELF"
+       }
+      },
+      {
+        "class": "DamageSpell",
+        "target": "FRIENDLY_HERO",
+        "value": 2,
+        "ignoreSpellDamage": true
+      }
+    ]
+  },
+  "attributes": {
+    "ECHO": true
+  },
+  "collectible": true,
+  "set": "CUSTOM",
+  "fileFormatVersion": 1
+}

--- a/cards/src/main/resources/cards/custom/group8/occultist/misc/spell_revelation
+++ b/cards/src/main/resources/cards/custom/group8/occultist/misc/spell_revelation
@@ -1,0 +1,30 @@
+{
+  "name": "Revelation",
+  "baseManaCost": 6,
+  "type": "SPELL",
+  "heroClass": "DARKGREEN",
+  "rarity": "EPIC",
+  "description": "Destroy all your Lun. Set the cost of all cards in your hand to (1).",
+  "targetSelection": "NONE",
+  "spell": {
+    "class": "MetaSpell",
+    "spells": [
+      {
+        "class": "ModifyMaxManaSpell",
+        "value": -10
+      },
+      {
+        "class": "CardCostModifierSpell",
+        "target": "FRIENDLY_HAND",
+        "cardCostModifier": {
+          "class": "CardCostModifier",
+          "value": 1,
+          "operation": "SET"
+        }
+      }
+    ]
+},
+"collectible": true,
+"set": "CUSTOM",
+"fileFormatVersion": 1
+}

--- a/cards/src/main/resources/cards/custom/group8/occultist/misc/spell_unholy_tremors
+++ b/cards/src/main/resources/cards/custom/group8/occultist/misc/spell_unholy_tremors
@@ -1,0 +1,30 @@
+{
+  "name": "Unholy Tremors",
+  "baseManaCost": 3,
+  "type": "SPELL",
+  "heroClass": "DARKGREEN",
+  "rarity": "COMMON",
+  "description": "Deal $1 damage to all minions, twice.",
+  "targetSelection": "NONE",
+  "spell": {
+    "class": "MetaSpell",
+    "spells": [
+      {
+        "class": "DamageSpell",
+        "target": "ALL_MINIONS",
+        "value": 1
+      },
+      {
+        "class": "ForceDeathPhaseSpell"
+      },
+      {
+        "class": "DamageSpell",
+        "target": "ALL_MINIONS",
+        "value": 1
+      }
+    ]
+  },
+  "collectible": true,
+  "set": "CUSTOM",
+  "fileFormatVersion": 1
+}

--- a/cards/src/main/resources/cards/custom/group8/occultist/ungoro/minion_distortoise.json
+++ b/cards/src/main/resources/cards/custom/group8/occultist/ungoro/minion_distortoise.json
@@ -12,7 +12,7 @@
     "spell": {
       "class": "DamageSpell",
       "target": "FRIENDLY_HERO",
-      "value": 2
+      "value": 3
     }
   },
   "attributes": {


### PR DESCRIPTION
10 new cards (2 legendaries, 2 epics, 3 rares, 3 commons, just the usual set)
Jikr, Occult One replaced with Aylith the Deceiver ( 7 Lun 5/5, Destroy your deck and replace it with two copies of your hand.)
_A bug fix_