### PR TITLE
New Occultist Set and some small changes

### DIFF
--- a/cards/src/main/resources/cards/custom/group8/occultist/misc/minion_gobogeg.json
+++ b/cards/src/main/resources/cards/custom/group8/occultist/misc/minion_gobogeg.json
@@ -6,13 +6,16 @@
   "baseAttack": 2,
   "baseHp": 6,
   "rarity": "LEGENDARY",
-  "description": "Whenever a friendly minion takes damage, give it +1/+1.",
-  "trigger": {
-    "eventTrigger": {
+  "description": "After a friendly minion survives damage, give it +1/+1.",
+  "eventTrigger": {
       "class": "DamageReceivedTrigger",
+      "targetPlayer": "SELF",
       "targetEntityType": "MINION",
-      "targetPlayer": "SELF"
-    },
+      "fireCondition": {
+        "class": "IsDeadCondition",
+        "target": "EVENT_TARGET",
+        "invert": true
+     },
     "spell": {
       "class": "BuffSpell",
       "target": "EVENT_TARGET",


### PR DESCRIPTION
Set containing 10 new cards: Goreball, Foul Manifest, Decaying Colossus, The Rotten, Otherwordly Truth,  
                                               Star Sculptor, Celestial Imprisonment, Cosmic Anomaly, Cosmos Rift and 
                                               Shaklatal, Cosmos' Scion.

Bugfixes: Bloody Reconstruction's dynamic text didnt work properly.
               Gobogeg changed to only work on surviving minions to avoid weird interactions.