### PR TITLE
Eldritech Reworked

### DIFF
--- a/cards/src/main/resources/cards/custom/group8/occultist/gvg/minion_eldritech.json
+++ b/cards/src/main/resources/cards/custom/group8/occultist/gvg/minion_eldritech.json
@@ -1,21 +1,17 @@
 {
-  "name": "Eldritech",
+  "name": "Mindsucker Matriarch",
   "baseManaCost": 4,
   "type": "MINION",
   "heroClass": "DARKGREEN",
   "baseAttack": 4,
-  "baseHp": 4,
+  "baseHp": 3,
   "rarity": "COMMON",
-  "race": "MECH",
-  "description": "Opener: Destroy a friendly Mech to summon another Eldritech.",
+  "race": "BEAST",
+  "description": "Opener: Destroy a friendly minion to summon another Mindsucker.",
   "battlecry": {
     "targetSelection": "FRIENDLY_MINIONS",
     "spell": {
       "class": "MetaSpell",
-      "filter": {
-        "class": "RaceFilter",
-        "race": "MECH"
-      },
       "spells": [
         {
           "class": "DestroySpell"


### PR DESCRIPTION
-From a 4 mana 4/4 Mech "Opener: Destroy a friendly Mech to summon another Eldritech."
 Renamed (Mindsucker Matriarch) and changed to 4 mana 4/3 Beast "Opener: Destroy a friendly minion to summon another Mindsucker"