### PR TITLE
Steed Sale fix

### DIFF
--- a/cards/src/main/resources/cards/custom/Dipsy/Trader/core/spell_steed_sale.json
+++ b/cards/src/main/resources/cards/custom/Dipsy/Trader/core/spell_steed_sale.json
@@ -17,8 +17,7 @@
         "class": "BothPlayersSpell",
         "spell": {
           "class": "SummonSpell",
-          "card": "token_horse",
-          "targetPlayer": "BOTH"
+          "card": "token_horse"
         }
       }
     ]


### PR DESCRIPTION
Steed Sale currently specifies a targetPlayer of BOTH, but from what I can tell it shouldn't since the BothPlayersSpell adds a target player on its own. The card is currently summong one more Horse for both players than it should, and I think this might be why.